### PR TITLE
feat: dynamic CSS generation for custom task status

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ An [Obsidian](https://obsidian.md) plugin that allows you to toggle the visibili
 - **Settings panel** - Configure status bar visibility and sub-bullet hiding
 - **Hide sub-bullets** - Optionally hide indented items beneath completed tasks (Edit/Live Preview mode only)
 - **Persistent state** - Remembers your preferences between sessions
-- **Custom task status support** - Only hides `[x]` and `[X]`, preserving custom statuses like `[?]`, `[!]`, `[/]`
+- **Custom task status support** - For example, you can only hides `[x]` and `[X]`, preserving custom statuses like `[?]`, `[!]`, `[/]`
 - **Cross-platform** - Works on desktop and mobile
 
 ### Demo
@@ -50,6 +50,8 @@ An [Obsidian](https://obsidian.md) plugin that allows you to toggle the visibili
 
 ### Supported Task Formats
 
+You can customize your hide markers. In default setting:
+
 The plugin only hides truly completed tasks:
 - `[x]` - Completed (hidden)
 - `[X]` - Completed (hidden)
@@ -75,6 +77,10 @@ Access settings via Settings → Community Plugins → Completed Task Display:
 - Only works in Edit and Live Preview modes
 - In Reading view, sub-bullets are automatically hidden with their parent task
 - Useful for cleaning up nested task lists while editing
+
+**Hide Markers**
+- List of markers that indicate a completed task. Separate multiple markers with spaces.
+- In default setting, it is "x" and "X"
 
 ## Development
 

--- a/styles.css
+++ b/styles.css
@@ -1,35 +1,3 @@
-/* Hide completed tasks in preview/reading mode - only [x] and [X] */
-/* Note: Edit mode toggling is handled by CodeMirror extension, so no body class needed there */
-/* But preview mode needs the body class to respect the toggle */
-body.hide-completed-tasks .markdown-preview-view ul > li.task-list-item[data-task="x"],
-body.hide-completed-tasks .markdown-preview-view ul > li.task-list-item[data-task="X"] {
-    display: none;
-}
-
-/* Hide sub-bullets under completed tasks in preview/reading mode */
-body.hide-completed-tasks .markdown-preview-view li.task-list-item[data-task="x"] ul,
-body.hide-completed-tasks .markdown-preview-view li.task-list-item[data-task="X"] ul {
-    display: none;
-}
-
-/* Hide completed task lines that have been replaced by our decorations */
-/* When a replace decoration is active, the line has data-task="x" but NO label (checkbox was removed) */
-/* AND it only contains widget buffers and contenteditable=false spans (content was replaced) */
-.markdown-source-view.mod-cm6 .cm-content > div.cm-line[data-task="x"]:not(:has(label)):has([contenteditable="false"]),
-.markdown-source-view.mod-cm6 .cm-content > div.cm-line[data-task="X"]:not(:has(label)):has([contenteditable="false"]),
-.markdown-source-view .cm-content > div.cm-line[data-task="x"]:not(:has(label)):has([contenteditable="false"]),
-.markdown-source-view .cm-content > div.cm-line[data-task="X"]:not(:has(label)):has([contenteditable="false"]) {
-    display: none !important;
-    height: 0 !important;
-    min-height: 0 !important;
-    max-height: 0 !important;
-    padding: 0 !important;
-    margin: 0 !important;
-    line-height: 0 !important;
-    overflow: hidden !important;
-    visibility: hidden !important;
-}
-
 /* Hide sub-bullets that have been replaced - must have HyperMD-list-line class and no visible content */
 /* This ensures we only hide actual list items, not random empty lines */
 .markdown-source-view.mod-cm6 .cm-content > div.cm-line.HyperMD-list-line:not(:has(label)):not(:has(.cm-list-1)):not(:has(.cm-list-2)):has([contenteditable="false"]),


### PR DESCRIPTION
### Changes
- Add `hideMarkers` setting.
- Add `updateDynamicCSS()` to build full‑scope selectors for each marker in `hideMarkers`.
- Apply dynamic CSS to:
  - **Preview mode** — ensure all configured markers are hidden/unhidden as expected.
  - **Edit mode**  — hide both the checkbox and task text for matching markers.
- Remove duplicated static CSS to prevent scope mismatch and toggle issues.
- Ensure consistent behavior between preview and edit views.
- Change `README.md` to describe feature above.

### Tests
- [x] Plugin loads without errors ✅ 2025-11-06
- [x] Ribbon button appears and works ✅ 2025-11-06
- [x] Command palette command works ✅ 2025-11-06
- [x] Status bar updates correctly ✅ 2025-11-06
- [x] State persists after restart ✅ 2025-11-06
- [x] No console errors ✅ 2025-11-06
- [x] Works in Reading mode ✅ 2025-11-06
- [x] Works in Edit/Live Preview mode ✅ 2025-11-06
- [x] Custom task statuses still visible (for task status changes) ✅ 2025-11-06